### PR TITLE
Remove the license image

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,9 +16,6 @@ theme:
 copyright: |
   Copyright &copy; Student Robotics contributors
   <br>
-  <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" style="padding:0.2em 0.2em 0 0;float:left;height:15px;width:80px;">
-    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" />
-  </a>
   This work is licensed under a
   <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
     Creative Commons Attribution-ShareAlike 4.0 International License


### PR DESCRIPTION
The text is, I believe, sufficient. Not having the image is also lighter weight on the page-load, avoids styling munging and IMO looks better. I thought the button would look nice when I added it, but now I think I was wrong.