### PR TITLE
Update kit handback plan

### DIFF
--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -49,7 +49,7 @@ This workflow is shown in the diagram below.
 
 ![Kit return flow](../diagrams/kit-return-desk-flow.svg)
 
-For each returned kit:
+## For each returned kit
 
 * Remove any batteries from the kit and store them separately
 * Seal the handles of the kit with tape

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -32,7 +32,7 @@ For each returned kit:
   Make all reasonable attempts to retrieve kit there and then i.e. if they've left a bit upstairs they go and get it.
 * If they do not have something, record it on a missing kit form.
 * If the kit return form indicates that they have more than a normal kit to return (i.e. they had broken kit and did not return it upon arrival), see if they can return it now. If not, record it on a missing kit form.
-* Indicate if all parts are present or if a missing kit form has been filled in on the kit return form (provided by me).
+* Indicate if all parts are present or if a missing kit form has been filled in on the kit return form.
 * Write down the part code of the Really Useful Box on the kit return form.
 * Get their team leader to sign and write their name on the kit return form.
 

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -19,12 +19,6 @@ rejected. When presented with a RUB full of kit, kit return staff should:
 
 **Don't let people leave the competition for good with any kit if they aren't on the list of teams authorised to keep their kit**
 
-For each returned kit:
-
-* Remove any batteries from the kit and store them separately
-* Seal the handles of the kit with tape
-* Stick a post-it on the end of the box with the team's TLA on it (to allow for double checking later on)
-* Stack the box with the post-it visible
 
 ## Teams returning kit
 
@@ -54,6 +48,14 @@ Teams leaving early should follow the same process as above, though we should pu
 This workflow is shown in the diagram below.
 
 ![Kit return flow](../diagrams/kit-return-desk-flow.svg)
+
+For each returned kit:
+
+* Remove any batteries from the kit and store them separately
+* Seal the handles of the kit with tape
+* Stick a post-it on the end of the box with the team's TLA on it (to allow for double checking later on)
+* Stack the box with the post-it visible
+
 
 ## Required Items
 You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible. The documents can be found in the [`kit-coordination-documents`](https://github.com/srobo/kit-coordination-documents) repo.

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -36,6 +36,10 @@ For each returned kit:
 * Write down the part code of the Really Useful Box on the kit return form.
 * Get their team leader to sign and write their name on the kit return form.
 
+### Teams leaving before competition-end
+
+If a team wishes to leave before the end of the competition, we should attempt to find any missing kit, rather than recording it on a missing kit form.
+
 ## Teams keeping kit
 
 * Write down the part code of the Really Useful Box on the kit return form.

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -47,6 +47,7 @@ If a team wishes to leave before the end of the competition, we should attempt t
 * Get their team leader to sign and write their name on the kit return form.
 * Give the team a return kit and ensure you inform them that they will be responsible for return shipping charges.
 * Stick the appropriate 'authorised to keep kit' sheet onto the kit of the Really Useful Box with tape.
+* Kit should be shipped to the postal address listed on [the website](https://studentrobotics.org/contact/).
 
 This workflow is shown in the diagram below.
 

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -36,6 +36,8 @@ For each returned kit:
 * Write down the part code of the Really Useful Box on the kit return form.
 * Get their team leader to sign and write their name on the kit return form.
 
+After the competition, the missing kit for teams will be sent to them by the teams coordinator to ensure the kit is returned. Kit should be shipped to the postal address listed on [the website](https://studentrobotics.org/contact/)
+
 ### Teams leaving before competition-end
 
 Teams leaving early should follow the same process as above, though we should push them to spend more time searching for any missing items they might have lost at the venue. If they are unable to find the items or are sure that they didn't bring them, then we should record the item on a missing kit form (as above).

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -38,7 +38,7 @@ For each returned kit:
 
 ### Teams leaving before competition-end
 
-If a team wishes to leave before the end of the competition, we should attempt to find any missing kit, rather than recording it on a missing kit form.
+Teams leaving early should follow the same process as above, though we should push them to spend more time searching for any missing items they might have lost at the venue. If they are unable to find the items or are sure that they didn't bring them, then we should record the item on a missing kit form (as above).
 
 ## Teams keeping kit
 

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -54,7 +54,7 @@ This workflow is shown in the diagram below.
 ![Kit return flow](../diagrams/kit-return-desk-flow.svg)
 
 ## Required Items
-You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible. The documents can be found in the [`kit-coordination-docs`](https://github.com/srobo/kit-coordination-docs) repo.
+You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible. The documents can be found in the [`kit-coordination-documents`](https://github.com/srobo/kit-coordination-documents) repo.
 
 * This documentation and flow chart.
 * Sign-out sheet.

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -58,7 +58,7 @@ For each returned kit:
 
 
 ## Required Items
-You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible. The documents can be found in the [`kit-coordination-documents`](https://github.com/srobo/kit-coordination-documents) repo.
+You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible. These documents should already be printed, but their source can be found in the [`kit-coordination-documents`](https://github.com/srobo/kit-coordination-documents) repo.
 
 * This documentation and flow chart.
 * Sign-out sheet.

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -54,7 +54,7 @@ This workflow is shown in the diagram below.
 ![Kit return flow](../diagrams/kit-return-desk-flow.svg)
 
 ## Required Items
-You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible.
+You should have the following items present for your duties. If you do not, please let the competition team coordinator know as soon as possible. The documents can be found in the [`kit-coordination-docs`](https://github.com/srobo/kit-coordination-docs) repo.
 
 * This documentation and flow chart.
 * Sign-out sheet.

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -19,28 +19,30 @@ rejected. When presented with a RUB full of kit, kit return staff should:
 
 **Don't let people leave the competition for good with any kit if they aren't on the list of teams authorised to keep their kit**
 
-* For teams returning their kit (the majority of teams):
-    * Check the contents against a list of parts expected in the kit.
-     Make all reasonable attempts to retrieve kit there and then i.e. if they've left a bit upstairs they go and get it.
-    * If they do not have something, record it on a missing kit form.
-    * If the kit return form indicates that they have more than a normal kit to return (i.e. they had broken kit and did not return it upon arrival), see if they can return it now. If not, record it on a missing kit form.
-    * Indicate if all parts are present or if a missing kit form has been filled in on the kit return form (provided by me).
-    * Write down the part code of the Really Useful Box on the kit return form.
-    * Get their team leader to sign and write their name on the kit return form.
+For each returned kit:
 
-* For teams keeping their kit (based on a list of teams authorised to do this):
-    * Write down the part code of the Really Useful Box on the kit return form.
-    * Give them two batteries, a battery charging bag and a charger+PSU. Record the part numbers of these five things on the kit return form.
-    * Get their team leader to sign and write their name on the kit return form.
-    * Give the team a return kit and ensure you inform them that they will be responsible for return shipping charges.
-    * Stick the appropriate 'authorised to keep kit' sheet onto the kit of the Really Useful Box with tape.
+* Remove any batteries from the kit and store them separately
+* Seal the handles of the kit with tape
+* Stick a post-it on the end of the box with the team's TLA on it (to allow for double checking later on)
+* Stack the box with the post-it visible
 
-* For each returned kit:
-    * Remove any batteries from the kit and store them separately
-    * Seal the handles of the kit with tape
-    * Stick a post-it on the end of the box with the team's TLA on it (to allow for double checking later on)
-    * Stack the box with the post-it visible
+## Teams returning kit
 
+* Check the contents against a list of parts expected in the kit.
+  Make all reasonable attempts to retrieve kit there and then i.e. if they've left a bit upstairs they go and get it.
+* If they do not have something, record it on a missing kit form.
+* If the kit return form indicates that they have more than a normal kit to return (i.e. they had broken kit and did not return it upon arrival), see if they can return it now. If not, record it on a missing kit form.
+* Indicate if all parts are present or if a missing kit form has been filled in on the kit return form (provided by me).
+* Write down the part code of the Really Useful Box on the kit return form.
+* Get their team leader to sign and write their name on the kit return form.
+
+## Teams keeping kit
+
+* Write down the part code of the Really Useful Box on the kit return form.
+* Give them two batteries, a battery charging bag and a charger+PSU. Record the part numbers of these five things on the kit return form.
+* Get their team leader to sign and write their name on the kit return form.
+* Give the team a return kit and ensure you inform them that they will be responsible for return shipping charges.
+* Stick the appropriate 'authorised to keep kit' sheet onto the kit of the Really Useful Box with tape.
 
 This workflow is shown in the diagram below.
 

--- a/docs/competition/teams/role-descriptions/kit-return.md
+++ b/docs/competition/teams/role-descriptions/kit-return.md
@@ -43,7 +43,7 @@ Teams leaving early should follow the same process as above, though we should pu
 * Get their team leader to sign and write their name on the kit return form.
 * Give the team a return kit and ensure you inform them that they will be responsible for return shipping charges.
 * Stick the appropriate 'authorised to keep kit' sheet onto the kit of the Really Useful Box with tape.
-* Kit should be shipped to the postal address listed on [the website](https://studentrobotics.org/contact/).
+* Kit should be shipped to the postal address listed on the website at https://studentrobotics.org/contact/, which is also included on the kit-authorisation form.
 
 This workflow is shown in the diagram below.
 


### PR DESCRIPTION
Fixes https://github.com/srobo/tasks/issues/115

I've intentionally _not_ encoded any location information for this years competition, so the documentation can remain year-agnostic. 

Primary changes:
- Reflow content. Headers are slightly nicer to visually grep than a single list
- Add special case for those leaving before end of competition.

## TODO
- [x] Find out where the related documents are
- [x] Find out where teams should ship their kits to after the competition (https://github.com/srobo/tasks/issues/186)