### PR TITLE
Add meta information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and [Kit Team][kit-team], as well as other activities.
 
 ## Installation
 
-In order to bootstrap this project you'll need:
+To run this project locally, you'll need:
 
 - Python (`>=3.5`)
 - `pip`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# RunBook
-
-Student Robotics Competition Program
+# Student Robotics Volunteer RunBook
 
 [![CircleCI](https://circleci.com/gh/srobo/runbook.svg?style=svg)](https://circleci.com/gh/srobo/runbook)
 
-# Installation
+## Installation
 
-## Requirements
+In order to bootstrap this project you'll need:
 
 - Python (`>=3.5`)
 - `pip`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![CircleCI](https://circleci.com/gh/srobo/runbook.svg?style=svg)](https://circleci.com/gh/srobo/runbook)
 
+The runbook aims to be a single source for all Student Robotics internal
+documentation. This includes information for the [Competition Team][competition-team]
+and [Kit Team][kit-team], as well as other activities.
+
+[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
+[kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team
+
 ## Installation
 
 In order to bootstrap this project you'll need:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,6 @@ Welcome to our runbook. This aims to be a single source for all Student Robotics
 internal documentation, including information for the [Competition Team][competition-team]
 and [Kit Team][kit-team] as well as other activities.
 
-[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
-[kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team
-
 ## Content Guidance
 
 The runbook aims to document all the Student Robotics specific information which
@@ -33,4 +30,6 @@ There are many cases where it should not contain the actual documentation:
    tooling, or recipes for using tooling which are common to us but too specific
    for general documentation.
 
+[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
+[kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team
 [ops-manual]: https://opsmanual.studentrobotics.org

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,22 @@ and [Kit Team][kit-team] as well as other activities.
 
 [competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
 [kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team
+
+## Content Guidance
+
+The runbook aims to document all the Student Robotics specific information which
+a volunteer might need. This includes the historic context for the way that
+things are currently done, the reasons behind that approach, as well as the
+instructions on how to do things.
+
+In that regard, the runbook aims to be _descriptive_ rather than _prescriptive_.
+We are always open to new ways to do things, though by recording the reasons
+for our current approach we aim to avoid needing to rediscover that repeatedly.
+
+The runbook aims to be complete as far as our own specific information goes,
+however creating documentation for external tools is deliberately out of scope.
+As a concrete example: we might include here some guidance on how _we_ use a
+tool (perhaps including recipes for patterns common to us), however we should
+not be directly documenting how to use the tool. In the latter case we should
+link to the tool's own documentation. (If that tool's documentation is
+insufficient then we should submit improvements to that project!)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Student Robotics Volunteer RunBook
+
+Welcome to our runbook. This aims to be a single source for all Student Robotics
+internal documentation, including information for the [Competition Team][competition-team]
+and [Kit Team][kit-team] as well as other activities.
+
+[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
+[kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Student Robotics Volunteer RunBook
+# Meta
 
 Welcome to our runbook. This aims to be a single source for all Student Robotics
 internal documentation, including information for the [Competition Team][competition-team]
@@ -18,10 +18,19 @@ In that regard, the runbook aims to be _descriptive_ rather than _prescriptive_.
 We are always open to new ways to do things, though by recording the reasons
 for our current approach we aim to avoid needing to rediscover that repeatedly.
 
-The runbook aims to be complete as far as our own specific information goes,
-however creating documentation for external tools is deliberately out of scope.
-As a concrete example: we might include here some guidance on how _we_ use a
-tool (perhaps including recipes for patterns common to us), however we should
-not be directly documenting how to use the tool. In the latter case we should
-link to the tool's own documentation. (If that tool's documentation is
-insufficient then we should submit improvements to that project!)
+### Scope Limitations
+
+The runbook aims to provide general information as far as our own specific
+information goes, so that it can always be a starting point for understanding.
+There are many cases where it should not contain the actual documentation:
+
+ * Information about Student Robotics' structure as a charity. This instead is
+   documented by the trustees in the [ops manual][ops-manual].
+ * Detailed information about internal (or external) tooling. These instead live
+   with the tooling so that the runbook is not coupled tightly to the
+   development of that tooling.
+   Note: the runbook _may_ contain guidance on our approach to using external
+   tooling, or recipes for using tooling which are common to us but too specific
+   for general documentation.
+
+[ops-manual]: https://opsmanual.studentrobotics.org

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Meta
+# Home
 
 Welcome to our runbook. This aims to be a single source for all Student Robotics
 internal documentation, including information for the [Competition Team][competition-team]


### PR DESCRIPTION
This fills out the root page with meta information about the runbook as well as including a brief summary in the root readme.
I'm not actually sure if the (hosted) homepage is the right place for this, but it feels like a useful place to start.

Fixes #23 