### PR TITLE
Add custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+runbook.studentrobotics.org

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: SR RunBook
-site_url: https://srobo.github.io/runbook/
+site_url: https://runbook.studentrobotics.org
 repo_url: https://github.com/srobo/runbook
 strict: true
 edit_uri: blob/master/docs/


### PR DESCRIPTION
Requires https://github.com/srobo/infrastructure/pull/6

Partially fixes https://github.com/srobo/runbook/issues/17
Partially fixes https://github.com/srobo/runbook/issues/58

This allows the runbook to be accessed via `runbook.studentrobotics.org`, which is a nicer domain, and easier to find. 