### PR TITLE
Update links to the teams within the ops-manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The runbook aims to be a single source for all Student Robotics internal
 documentation. This includes information for the [Competition Team][competition-team]
 and [Kit Team][kit-team], as well as other activities.
 
-[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
-[kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team
+[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-team
+[kit-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/kit-team
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,6 @@ There are many cases where it should not contain the actual documentation:
    tooling, or recipes for using tooling which are common to us but too specific
    for general documentation.
 
-[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
-[kit-team]: https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team
+[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-team
+[kit-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/kit-team
 [ops-manual]: https://opsmanual.studentrobotics.org

--- a/docs/volunteering/glossary.md
+++ b/docs/volunteering/glossary.md
@@ -19,7 +19,7 @@ _Competition year_:
 : the 6 months (or so) between _Kickstart_ and the _Competition_ during which
 teams build their robots; see also _SRnnnn_
 
-[_Competition Team_](https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team):
+[_Competition Team_](https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-team):
 
 : the group of volunteers responsible for delivering a particular year's
 _Competition programme_
@@ -37,7 +37,7 @@ _Kickstart_:
 
 : the start of the competition year, when we hand out kits to teams
 
-[_Kit Team_](https://opsmanual.studentrobotics.org/v/master/annual-robotics-competition/kit-team):
+[_Kit Team_](https://opsmanual.studentrobotics.org/annual-robotics-competition/kit-team):
 
 : the group of volunteers responsible for maintenance and development of the
 _Team Kits_ and for supporting competitors in using those kits


### PR DESCRIPTION
This reflects the recent renaming of the Competition Team and that the Kit Team is now present in the latest published version.