### PR TITLE
Host runbook at path on primary domain

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Student Robotics Volunteer Runbook
-site_url: https://srobo.github.io/runbook/
+site_url: https://studentrobotics.org/runbook/
 repo_url: https://github.com/srobo/runbook
 strict: true
 edit_uri: blob/master/docs/


### PR DESCRIPTION
Replaces #64

Requires https://github.com/srobo/website/pull/192

Partially fixes https://github.com/srobo/runbook/issues/17
Partially fixes https://github.com/srobo/runbook/issues/58

This allows the runbook to be accessed via `studentrobotics.org/runbook/`, which is nicer and easier to find. It also matches the regular pattern of hosting things as paths rather than subdomins, which matches 99% of everything else we do.

This changes the URLs generated, so the previous domain will still work, but any and all links will be redirected back to this primary url