### PR TITLE
Add a page noting volunteer teams and their historical members

### DIFF
--- a/docs/volunteering/teams.md
+++ b/docs/volunteering/teams.md
@@ -1,0 +1,55 @@
+# Volunteer Teams
+
+Student Robotics has 2 teams which organise the operations regarding the wider competition programme. Each team is organised by its respective committee.
+
+- [Competition Team](https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-team)
+- [Kit Team](https://opsmanual.studentrobotics.org/annual-robotics-competition/kit-team)
+
+## 2020
+
+### Competition Team
+
+##### Committee
+
+- Andy Barrett-Sprott
+- Andy Busse
+- Jake Howard
+
+##### Members
+
+- Antoine Petty
+- James Seden Smith
+- Jenny Fletcher
+- Peter Law
+
+### Kit Team
+
+##### Committee
+
+- Dan Trickey
+- Kajetan Champlewski
+- Kier Davis
+- Rob Gilton
+- Tom Wheal
+
+##### Members
+
+TBC
+
+## 2019
+
+In 2019, the Competition Team was known as the Core Team.
+
+### Core Team
+
+- Alistair Lynn
+- Andrew Barrett-Sprot
+- Andy Busse
+- Antoine Petty
+- Anton Nikitin
+- Dan Trickey
+- Holly Holder
+- Jake Howard
+- Kajetan Champlewski
+- Peter Law
+- Tyler Ward

--- a/docs/volunteering/teams.md
+++ b/docs/volunteering/teams.md
@@ -5,7 +5,7 @@ Student Robotics has 2 teams which organise the operations regarding the wider c
 - [Competition Team](https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-team)
 - [Kit Team](https://opsmanual.studentrobotics.org/annual-robotics-competition/kit-team)
 
-## 2020
+## SR2020
 
 ### Competition Team
 
@@ -36,9 +36,9 @@ Student Robotics has 2 teams which organise the operations regarding the wider c
 
 TBC
 
-## 2019
+## SR2019
 
-In 2019, the Competition Team was known as the Core Team.
+During SR2019, the Competition Team was known as the Core Team.
 
 ### Core Team
 


### PR DESCRIPTION
Add a list of members of the volunteer teams.

I'm not especially happy with the opening line. I'd like to add more emphasis that it's not just these volunteers who do everything in SR, and that every volunteer helps, but I couldn't find wording I was happy with. Input appreciated!