### PR TITLE
Document kit return

### DIFF
--- a/docs/kit/logistics/kit-loan-extension.md
+++ b/docs/kit/logistics/kit-loan-extension.md
@@ -1,0 +1,25 @@
+# Kit Loan Extension
+
+As per appendix A.2 of the [rules][rules], teams may request to keep the kit after the competition.
+
+## Requesting a loan extension
+
+Instructions for teams to request a loan extension are located in A.2 of the [rules][rules]. Generally this involves emailing Student Robotics before a specific deadline. Requests which come in after this deadline should be denied, unless there are exceptional circumstances.
+
+The rules do not define how long the loan extension can be given for. Historical this has been anywhere to a few weeks after the competition to 2 months. This is the date the kit should be returned, rather than when the teams dispatch it.
+
+If a team is granted a loan extension, make sure they are aware, and explicitly note when the kit is expected back.
+
+[Example email for kit loan extension](https://github.com/srobo/team-emails/blob/master/SR2019/2019-03-11-competition-information.md#kit-loan-extension)
+
+## Kit Return Pack
+
+Teams who have requested loan extensions should be issued with kit return packs at the end of the competition. The pack is mostly comprised of jiffy bags suitable for the fragile boards, and stickers. Teams should be instructed to securely pack and plastic wrap the RUBs for shipping, ensuring the contents can't roll around.
+
+## Returning the kit
+
+The teams are responsible for arranging and paying for a courier to return the kit to us.
+
+When leaving the competition, teams should also be issued with [this form](https://github.com/srobo/kit-coordination-documents/tree/master/authorized-to-keep-kit), ensuring they've got all the information they need to return the kit back to us.
+
+[rules]: https://studentrobotics.org/docs/rules/

--- a/docs/kit/logistics/kit-loan-extension.md
+++ b/docs/kit/logistics/kit-loan-extension.md
@@ -22,4 +22,6 @@ The teams are responsible for arranging and paying for a courier to return the k
 
 When leaving the competition, teams should also be issued with [this form](https://github.com/srobo/kit-coordination-documents/tree/master/authorized-to-keep-kit), ensuring they've got all the information they need to return the kit back to us.
 
+[Example email prompting teams about kit return](https://github.com/srobo/team-emails/blob/master/SR2019/2019-05-15-kit-chase-round-1.md)
+
 [rules]: https://studentrobotics.org/docs/rules/

--- a/docs/kit/logistics/kit-return.md
+++ b/docs/kit/logistics/kit-return.md
@@ -4,7 +4,7 @@
 
 At the end of the competition, teams are asked to return their kits to reception. Appendix A.1 of the [rules](https://studentrobotics.org/docs/rules/) notes the list of items expected back, items on this list are not expected back, but it's fine for them to be. At reception, the contents of the RUB should be checked to ensure it contains at least all the items on this list. Ensure there is nothing else left in the RUB the team may want back.
 
-The [Kit Contents Checklist](https://github.com/srobo/kit-coordination-documents/tree/master/kit-contents-checklist) should be used to ensure all the items are present and correct. 1 form should be used per team, and this form should be kept to prove the kit was returned correctly. Once completed, keep the form with its respective kit.
+The [Kit Contents Checklist](https://github.com/srobo/kit-coordination-documents/tree/master/kit-contents-checklist) should be used to ensure all the items are present and correct. One form should be used per team, and this form should be kept to prove the kit was returned correctly. Once completed, keep the form with its respective kit.
 
 ### Missing Items
 

--- a/docs/kit/logistics/kit-return.md
+++ b/docs/kit/logistics/kit-return.md
@@ -1,0 +1,19 @@
+# Kit Return
+
+## At the competition
+
+At the end of the competition, teams are asked to return their kits to reception. Appendix A.1 of the [rules](https://studentrobotics.org/docs/rules/) notes the list of items expected back, items on this list are not expected back, but it's fine for them to be. At reception, the contents of the RUB should be checked to ensure it contains at least all the items on this list. Ensure there is nothing else left in the RUB the team may want back.
+
+The [Kit Contents Checklist](https://github.com/srobo/kit-coordination-documents/tree/master/kit-contents-checklist) should be used to ensure all the items are present and correct. 1 form should be used per team, and this form should be kept to prove the kit was returned correctly. Once completed, keep the form with its respective kit.
+
+### Missing Items
+
+If a kit is not complete, the [Missing Kit Form](https://github.com/srobo/kit-coordination-documents/tree/master/missing-kit-form) should be completed noting which items of kit have not been returned. After the competition, these forms are tabulated and the teams contacted to ensure the safe return of the items of kit.
+
+[Example email for teams with outstanding single items of kit](https://github.com/srobo/team-emails/blob/master/SR2019/2019-05-28-single-item-kit-chase.md)
+
+If the team cannot find the item of kit, a like-for-like replacement (or as close as possible) should be ordered and shipped to the address listed for [Kit Loan Extension](./kit-loan-extension.md).
+
+## After the competition
+
+Kits being returned after the competition, either because they didn't attend the competition, or because they had a [Kit Loan Extension](./kit-loan-extension.md) should follow the [Kit Loan Extension](./kit-loan-extension.md) instructions for returning the kit.

--- a/docs/kit/logistics/transport/procedures.md
+++ b/docs/kit/logistics/transport/procedures.md
@@ -103,10 +103,6 @@ Begin by requesting the following information from the Team Coordinator for the 
 
 At the end of the competition we have the majority of the kits returned to us. The Competition Team Coordinator is responsible for managing the return process. The Kit Logistics Coordinator can aid in this process and is responsible for shipping the kits to storage after they have been returned. TBD.
 
-## Ensuring the timely return of kits not returned at the competition
-
-Some teams will have been given permission to retain their kit for a while after the competition. The teams are responsible for arranging and paying for a courier to return the kit to us. The Kit Logistics Coordinator is responsible for assisting teams in this process and ensuring that all kits are returned by the 1st June of the same year that the competition was held in. TBD.
-
 ## Shipping of non-team kits and development tools to volunteers
 
 Non-team kits (those that are classed as development, support, PR or local) and development tools need to be shipped around as deemed appropriate by the person responsible for their allocation. That being the Kit Coordinator for development kits and tools, the Kit Support Coordinator for support kits, the PR coordinator for PR kits and the Team Coordinator for local kits. TBD.


### PR DESCRIPTION
Document the process for kit return / kit loan extension.

Related to https://github.com/srobo/tasks/issues/452 and https://github.com/srobo/tasks/issues/451

Note: This PR is meant to reflect how it was done in SR2019, rather than how it should be done / will be done for SR2020. Changes for that should come in a separate PR.