### PR TITLE
We use Mixtape for Virtual Competition livestreams now

### DIFF
--- a/docs/competition/livestream/README.md
+++ b/docs/competition/livestream/README.md
@@ -12,6 +12,8 @@ We use [OBS Studio](https://obsproject.com/) as the livestreaming software used 
 
 OBS configuration is split into 2 fundamental objects: Scenes and Sources. A scene is the thing shown on screen, which is made up of multiple sources.
 
+For virtual competition livestreams we use [SRComp Mixtape](https://github.com/srobo/srcomp-mixtape) to automate the playback of match videos and the scene transitions at either end of each match. See [Mixtape's documentation](https://github.com/srobo/srcomp-mixtape#configuration) for how to create a suitable playlist file to configure mixtape.
+
 ## Hardware
 
 The hardware requirements for hosting a livestream are not large, however a stable internet connection is a must. A dedicated GPU is useful to ensure the system isn't taxed too heavily.

--- a/docs/competition/livestream/matches.md
+++ b/docs/competition/livestream/matches.md
@@ -23,15 +23,4 @@ The overlay should be present on all scenes which display matches, and perhaps a
 
 ## Video Scheduler
 
-In a simulator-based competition, matches are pre-recorded. To assist with the automatic queueing and playback of matches in line with the competition schedule, we have a [video scheduler](https://github.com/RealOrangeOne/livestream-video-scheduler).
-
-The video scheduler is currently a fork of the [overlay](#overlay), with much of the functionality removed. Therefore, it's brought into OBS in the same way, just without the chroma key.
-
-### Playback issues
-
-Due to issues with the OBS browser, some videos will not play directly through it. This manifests as it requesting the video file, but not being able to play it. There are a few solutions to this:
-
-- Transcode the videos to `webm`, as this can be played correctly
-- Open the scheduler in an external browser, and add to OBS via a screen share.
-
-This issue has mostly been seen on Linux, and a long-term solution is being looked for.
+In a simulator-based competition, matches are pre-recorded. To assist with the automatic queueing and playback of matches in line with the competition schedule, we use [SRComp Mixtape](https://github.com/srobo/srcomp-mixtape). Mixtape can also control the scene transitions at either end of each match. See [Mixtape's documentation](https://github.com/srobo/srcomp-mixtape#configuration) for how to create a suitable playlist file to configure mixtape.

--- a/docs/competition/virtual-competitions/competition-session-checklist.md
+++ b/docs/competition/virtual-competitions/competition-session-checklist.md
@@ -32,7 +32,6 @@ This checklist enumerates the tasks that need to be completed to run a virtual c
 
 - Get a copy of the updated compstate
 - Run the simulations
-- Transcode the generated video files to WebM
 - Upload the entire output to our Google Drive Folder
 
 ## Pre Go Live


### PR DESCRIPTION
This removes the need to re-encode the videos as WebM and is another piece of software to setup as part of the livestream.