### PR TITLE
Install dependencies when deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             - checkout
             - restore_cache:
                 key: cache-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - run: pip install -r requirements.txt
             - deploy:
                 name: Deploy to Github Pages
                 command: ./.circleci/deploy.sh


### PR DESCRIPTION
Broken in #115 

Previously, the entire virtualenv was cached. Now we're only caching the pip cache, so we need to re-install the packages before they're available to use