### PR TITLE
Move to a supported version of the mermaid plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,14 +32,12 @@ extra:
     - type: twitter
       link: https://twitter.com/studentrobotics
 
-extra_javascript:
-  - https://unpkg.com/mermaid@7.1.2/dist/mermaid.min.js
-
 # Extensions
 markdown_extensions:
-  # Note: the markdownmermaid plugin doesn't work properly if we enable either
-  # of the following extensions, so we keep them disabled. If we turn out to
-  # need code blocks in this project, we can re-evaluate this then.
+  # Note: the mermaid2 plugin also relies on code blocks for graphs, which isn't
+  # completely compatible with the following extensions, so we keep them
+  # disabled. If we turn out to need code blocks in this project, we can
+  # solve this then. See https://github.com/fralau/mkdocs-mermaid2-plugin#using-mermaid-and-code-highlighting-at-the-same-time.
   # - markdown.extensions.codehilite
   # - pymdownx.superfences
 
@@ -70,4 +68,4 @@ markdown_extensions:
 plugins:
   - search
   - markdownextradata
-  - markdownmermaid
+  - mermaid2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@ mkdocs==1.0.4
 mkdocs-material==4.1.1
 mdx-include==1.3.3
 mkdocs-markdownextradata-plugin==0.0.5
+mkdocs-mermaid2-plugin==0.5.1
 
 # Something in 3.3 (specifically `(3.2.2, 3.3.4]`) breaks mermaid rendering.
 # Haven't looked into what just yet.
 markdown<=3.3"
-
-git+https://github.com/pugong/mkdocs-mermaid-plugin@abf14392b0ed0c7022210b32c4e7c9c3e4c5c68a


### PR DESCRIPTION
See https://github.com/pugong/mkdocs-mermaid-plugin/issues/5, in particular https://github.com/pugong/mkdocs-mermaid-plugin/issues/5#issuecomment-613945139, which resulted in https://github.com/fralau/mkdocs-mermaid2-plugin.
The latter has more activity and appears to have resolved some of the known issues with the previous plugin.