### PR TITLE
Upgrade mkdocs and mkdocs-material

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,12 +4,14 @@ repo_url: https://github.com/srobo/runbook
 strict: true
 edit_uri: blob/master/docs/
 theme:
-  logo:
-    icon: library_books
-  favicon: favicon.ico
-  name: material
-  feature:
-    tabs: true
+  name: 'material'
+  icon:
+    logo: fontawesome/solid/book
+  favicon: 'favicon.ico'
+  language: 'en'
+  features:
+    - navigation.tabs
+    - navigation.instant
   palette:
     primary: 'blue'
     accent: 'blue'
@@ -25,11 +27,11 @@ copyright: |
 # Customization
 extra:
   social:
-    - type: globe
+    - icon: fontawesome/solid/globe
       link: https://studentrobotics.org
-    - type: github-alt
+    - icon: fontawesome/brands/github-alt
       link: https://github.com/srobo
-    - type: twitter
+    - icon: fontawesome/brands/twitter
       link: https://twitter.com/studentrobotics
 
 # Extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-mkdocs==1.0.4
-mkdocs-material==4.1.1
-mdx-include==1.3.3
-mkdocs-markdownextradata-plugin==0.0.5
-mkdocs-mermaid2-plugin==0.5.1
+mkdocs==1.2.2
+mkdocs-material==7.3.1
+mdx-include==1.4.1
+mkdocs-markdownextradata-plugin==0.2.4
+mkdocs-mermaid2-plugin==0.5.2
 
 # Something in 3.3 (specifically `(3.2.2, 3.3.4]`) breaks mermaid rendering.
 # Haven't looked into what just yet.


### PR DESCRIPTION
Upgrades mkdocs and other dependencies, notably upgrading mkdocs-material to v7.

Also updated `mkdocs.yml` for slight changes in config. Some icons are slightly different due to the old icon-set no longer being available.

**Help Requested**: I am unable to work out why the menu structure doesn't render as intended.

Preview when rendered: https://static.trickey.io/runbook/

(I ended up on this adventure when attempting to do #2 as a quick thing)
