### PR TITLE
Add the start of an offboarding checklist

### DIFF
--- a/docs/volunteering/offboarding-checklist.md
+++ b/docs/volunteering/offboarding-checklist.md
@@ -14,6 +14,9 @@ their teams' committees to each run through this checklist.
   important they know that they're welcome back and we're grateful for the
   support they have given us in the past.
 
+- Arrange for the volunteer to return any equipment which belongs to the
+  charity.
+
 - If possible, ask why they're leaving. This should be conversational to build
   understanding, it's not about trying to convince them to stay.
 

--- a/docs/volunteering/offboarding-checklist.md
+++ b/docs/volunteering/offboarding-checklist.md
@@ -1,0 +1,19 @@
+# Offboarding Checklist
+
+From time to time volunteers may decide that they would like to leave the
+organisation to focus on other things. When this happens we should try to ensure
+that anything they're responsible for is handed over to another volunteer.
+
+This checklist aims to provide prompts for things which might need to be handed
+over.
+
+## Third Party Services
+
+- Check [the list][list-third-party-services] of who is configured as the
+  "owner" of each third party service that we use and transfer as needed.
+
+- Check whether there are any other services which the volunteer manages
+  directly (e.g: packages on PyPI, projects in ReadTheDocs) and either confirm
+  that they're happy to continue maintaining those or transfer as needed.
+
+[list-third-party-services]: https://docs.google.com/spreadsheets/d/1uh8yfaMWfHd0MYgBx2PNkxYZZd4ZBv9NK9VD3hDt4GI/edit#gid=0

--- a/docs/volunteering/offboarding-checklist.md
+++ b/docs/volunteering/offboarding-checklist.md
@@ -5,7 +5,17 @@ organisation to focus on other things. When this happens we should try to ensure
 that anything they're responsible for is handed over to another volunteer.
 
 This checklist aims to provide prompts for things which might need to be handed
-over.
+over. When a volunteer leaves the organisation, it is the responsibility of
+their teams' committees to each run through this checklist.
+
+## The Volunteer
+
+- Thank the volunteer for their support. While they may be leaving us, it's
+  important they know that they're welcome back and we're grateful for the
+  support they have given us in the past.
+
+- If possible, ask why they're leaving. This should be conversational to build
+  understanding, it's not about trying to convince them to stay.
 
 ## Third Party Services
 


### PR DESCRIPTION
This is likely very incomplete, however provides a place for us to start adding things as we discover them.

The scope here is really the checklist of services, so it is explicitly _not_ the scope of this PR to make this checklist a complete guide for offboarding. (That would be great to do, but separately).

Fixes https://github.com/srobo/infrastructure-team-minutes/issues/12