### PR TITLE
Pin more package versions we need

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ mkdocs-mermaid2-plugin==0.5.1
 # Something in 3.3 (specifically `(3.2.2, 3.3.4]`) breaks mermaid rendering.
 # Haven't looked into what just yet.
 markdown<=3.3
+
+# Jinja2 v3 is breaking for mkdocs. Markupsafe 2.1 is breaking for Jinja2 v2
+jinja2<3
+markupsafe<2.1


### PR DESCRIPTION
Until we can upgrade mkdocs (#124 or #122) we're somewhat stuck with pinning old versions when things break.