### PR TITLE
Alternate roles for stopping the competition

### DIFF
--- a/docs/competition/event/incident-management.md
+++ b/docs/competition/event/incident-management.md
@@ -42,7 +42,8 @@ Due to the impact of stopping the competition, ability to do so is restricted to
 
 * Health and Safety Coordinator,
 * Event Coordinator,
-* Head Judge,
+* Head Shepherd,
+* Event Tech Lead,
 * Majority decision from Trustees.
 
 Stopping the competition will be indicated by a call over the radio of "This is _role_; stop the competition."


### PR DESCRIPTION
The head judge should be a role of adjudication not organisation. Head shepherd and the lead of event tech (lighting, construction, etc.) are better placed to assess an incident.