### PR TITLE
Add an initial page on Information Security

### DIFF
--- a/docs/infrastructure/machine-setup.md
+++ b/docs/infrastructure/machine-setup.md
@@ -33,6 +33,8 @@ infrastructure](./requesting-infrastructure.md#mythic-beasts).
 
 ## Securing the OS
 
+<!-- Updating this? Also update "Servers" in ./security.md -->
+
 Exactly what is needed to secure a new machine will depend on its intended
 use-case, operating system and other factors. In general though we expect that:
 

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -27,3 +27,20 @@ Useful links:
 - [Slack two factor authentication](https://slack.com/intl/en-gb/help/articles/204509068-Set-up-two-factor-authentication-Set-up-two-factor-authentication)
 
 [wikipedia-mfa]: https://en.wikipedia.org/wiki/Multi-factor_authentication
+
+## Servers
+
+<!-- Updating this? Also update "Securing the OS" in ./machine-setup.md -->
+
+Exactly what is needed to secure a given server will depend on its intended
+use-case, operating system and other factors. In general though we expect that:
+
+* the firewall will block everything that's not needed
+* root SSH is disabled
+* password SSH is disabled (i.e: keys only)
+* individuals have their own user accounts
+
+These are included for all machines configured via our [ansible config][srobo-ansible],
+which also creates users for members of the Infrastructure Team.
+
+[srobo-ansible]: https://github.com/srobo/ansible/

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -1,0 +1,29 @@
+# Security
+
+!!! note
+    This page is about digital & information security.
+
+We take security considerations very seriously.
+If you have any concerns please contact the Infrastructure Committee in the
+first instance or the Trustees.
+
+## Multi Factor Authentication
+
+[Multi-factor authentication][wikipedia-mfa] (MFA) offers improved
+authentication when accessing online accounts by requiring that the user provide
+stronger proof of their identity before accessing an account.
+
+All volunteers are encouraged to make use of multi-factor authentication on all
+platforms which support it. Volunteers in positions of responsibility are
+strongly encouraged to do so and should discuss with the Infrastructure
+Committee any cases where this is impractical.
+
+Useful links:
+
+- [Discord two factor authentication](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication)
+- [GitHub two factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
+- [Google two factor authentication](https://support.google.com/accounts/answer/185839)
+- [Mythic Beasts two factor authentication](https://www.mythic-beasts.com/blog/2020/01/27/two-factor-auth-totp-now-available/)
+- [Slack two factor authentication](https://slack.com/intl/en-gb/help/articles/204509068-Set-up-two-factor-authentication-Set-up-two-factor-authentication)
+
+[wikipedia-mfa]: https://en.wikipedia.org/wiki/Multi-factor_authentication


### PR DESCRIPTION
Mostly so that we can record a policy on using multi-factor authentication.

Also mentions server security, copying & linking content from where this was already covered.

PR for visibility before adopting this policy more formally.