### PR TITLE
Rearrangements of areas

### DIFF
--- a/docs/programme/area-owners.md
+++ b/docs/programme/area-owners.md
@@ -19,6 +19,7 @@ Responsibilities:
 * Fire safety
 * Overnight safety at venues
 * Power tools area
+* Safety policy (pit rules, etc.)
 
 ## Media / Press
 
@@ -59,6 +60,7 @@ Responsibilities:
 * Announcements
 * Challenges
 * Feedback & surveys
+* Tech days venues
 
 ## Kit
 
@@ -80,8 +82,6 @@ Responsibilities:
 * Teardown
 * Tech hire
 * Venue interaction
-* Kickstart venues
-* Tech day venues
 * Lighting rig
 * In-venue audio
 * Arena props & build


### PR DESCRIPTION
Specifically:

* For reasons mainly of workload, tech days move out of event logistics to teams;
* As we aren't doing physical Kickstarts, that part is dropped (it can be reädded if needs be);
* Pit rules is made explicitly part of Health & Safety.