### PR TITLE
Bump NodeJS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
 
       - name: Install
         run: npm install


### PR DESCRIPTION
I've been using 18 for a while locally and that's been fine. Relying on CI to check if 22 is also fine.