### PR TITLE
Scope concurrency limits to branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
There's no need to limit the concurrency between one PR run and another, nor a PR run and main.