### PR TITLE
Add SR2025 competition setup plan

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -48,6 +48,7 @@ Spanton
 Startech
 Stormpress
 StudentRobotics
+SUSU
 Turnigy
 Unicol
 Sainsbury's

--- a/docs/competition/event/sr2025-setup.md
+++ b/docs/competition/event/sr2025-setup.md
@@ -4,7 +4,7 @@ The event logistics area is responsible for the setup at the SR2025 competition.
 
 The number following each team is the number of people that team should ideally have.
 
-## Saturday
+## Thursday
 
 ```mermaid
 gantt
@@ -16,7 +16,7 @@ gantt
     Lay test arena carpet :testCarpet, 09:00, 1h
     Lay main arena carpet :mainCarpet, 10:30, 1h
     Lunch :lunchA, 12:30, 1h
-    Setup corner screens :setupCornerScreens, 13:30, 2h
+    Mount and setup arena screens :setupCornerScreens, 13:30, 2h
 
     section Team B (4)
     Assemble test arena walls :testWalls, after testCarpet, 1h
@@ -28,7 +28,6 @@ gantt
     Setup score entry table :scoreEntry, after l2Helpdesk, 0.25h
     Setup staging tables :stagingTables, after scoreEntry, 0.25h
     Lunch :lunchC, 12:30, 1h
-    Mount and setup arena screens :arenaScreens, 14:30, 1.5h
 
     section Team D (2)
     Add test arena markings :testMarkings, after testWalls, 1.5h
@@ -51,7 +50,7 @@ gantt
     Lunch :lunchSUSU, 12:30, 1h
 ```
 
-## Sunday
+## Friday
 
 ```mermaid
 gantt
@@ -62,7 +61,7 @@ gantt
     section Team A (4)
     Clear pit areas :clearPitAreas, 09:00, 1h
     Setup pit tables :setupPitTables, after clearPitAreas, 1h
-    Place arena barriers :arenaBarriers, 11:30, 0.5h
+    Setup venue screens :setupVenueScreens, 11:30, 1h
 
     section Team B (2)
     Place venue signage :venueSignage, 09:00, 1h
@@ -72,8 +71,10 @@ gantt
     section Team C (2)
     Setup helpdesk and battery charging :setupHelpdesk, 09:00, 1h
     Setup power tools area :setupPowerTools, after setupHelpdesk, 1h
+    Place arena barriers :arenaBarriers, 11:30, 0.5h
 
     section SUSU Crew
     Setup pit power :setupPitPower, 10:30, 1h
+    Setup venue screens :setupVenueScreensSUSU, 11:30, 1h
     Lunch :lunchSUSU, 12:30, 45m
 ```

--- a/docs/competition/event/sr2025-setup.md
+++ b/docs/competition/event/sr2025-setup.md
@@ -73,6 +73,12 @@ gantt
     Setup power tools area :setupPowerTools, after setupHelpdesk, 1h
     Place arena barriers :arenaBarriers, 11:30, 0.5h
 
+    section Team D (4)
+    Make swag bags :swagBags, 09:00, 3.5h
+
+    section Team E (2)
+    Add hi-vis jacket labels :jacketLabels, 09:00, 1h
+
     section SUSU Crew
     Setup pit power :setupPitPower, 10:30, 1h
     Setup venue screens :setupVenueScreensSUSU, 11:30, 1h

--- a/docs/competition/event/sr2025-setup.md
+++ b/docs/competition/event/sr2025-setup.md
@@ -1,0 +1,77 @@
+# SR2025 Competition Setup Plan
+
+The event logistics area is responsible for the setup at the SR2025 competition. Volunteers will be split into teams with a plan for the day, and each team will have a leader.
+
+## Saturday
+
+```mermaid
+gantt
+    title SR2025 Setup (Thursday)
+    dateFormat HH:mm
+    axisFormat %H:%M
+
+    section Team A (3)
+    Lay test arena carpet :testCarpet, 09:00, 1h
+    Lay main arena carpet :mainCarpet, 10:30, 1h
+    Lunch :lunchA, 12:30, 1h
+    Setup corner screens :setupCornerScreens, 13:30, 2h
+
+    section Team B (4)
+    Assemble test arena walls :testWalls, after testCarpet, 1h
+    Assemble main arena walls :mainWalls, after mainCarpet, 1h
+    Lunch :lunchB, 12:30, 1h
+
+    section Team C (2)
+    Setup level 2 helpdesk :l2Helpdesk, 09:00, 1.5h
+    Setup score entry table :scoreEntry, after l2Helpdesk, 0.25h
+    Setup staging tables :stagingTables, after scoreEntry, 0.25h
+    Lunch :lunchC, 12:30, 1h
+    Mount and setup arena screens :arenaScreens, 14:30, 1.5h
+
+    section Team D (2)
+    Add test arena markings :testMarkings, after testWalls, 1.5h
+    Lunch :lunchD, 12:30, 1h
+    Add test arena markings :testMarkings2, after lunchD, 0.5h
+    Add main arena markings :mainMarkings, after testMarkings2, 2h
+
+    section Team E (2)
+    Place test arena wall markers :testWallMarkers, after testWalls, 1.5h
+    Lunch :lunchE, 12:30, 1h
+    Place main arena wall markers :mainWallMarkers, after lunchE, 1.5h
+
+    section Team F (2)
+    Setup livestream :livestream1, 09:00, 3.5h
+    Lunch :lunchF, 12:30, 1h
+    Setup livestream :livestream2, after lunchF, 2.5h
+
+    section SUSU Crew
+    Rig Cube :rigCube, 08:30, 2h
+    Lunch :lunchSUSU, 12:30, 1h
+```
+
+## Sunday
+
+```mermaid
+gantt
+    title SR2025 Setup (Friday)
+    dateFormat HH:mm
+    axisFormat %H:%M
+
+    section Team A (4)
+    Clear pit areas :clearPitAreas, 09:00, 1h
+    Setup pit tables :setupPitTables, after clearPitAreas, 1h
+    Place arena barriers :arenaBarriers, 11:30, 0.5h
+
+    section Team B (2)
+    Place venue signage :venueSignage, 09:00, 1h
+    Setup reception tables :receptionTables, 10:30, 0.5h
+    Label pit tables :labelPitTables, 11:30, 1h
+
+    section Team C (2)
+    Setup helpdesk and battery charging :setupHelpdesk, 09:00, 1h
+    Setup power tools area :setupPowerTools, after setupHelpdesk, 1h
+
+    section SUSU Crew
+    Setup pit power :setupPitPower, 10:30, 1h
+    Lunch :lunchSUSU, 12:30, 45m
+```

--- a/docs/competition/event/sr2025-setup.md
+++ b/docs/competition/event/sr2025-setup.md
@@ -2,6 +2,8 @@
 
 The event logistics area is responsible for the setup at the SR2025 competition. Volunteers will be split into teams with a plan for the day, and each team will have a leader.
 
+The number following each team is the number of people that team should ideally have.
+
 ## Saturday
 
 ```mermaid


### PR DESCRIPTION
This adds the setup plan for the SR2025 competition.

Roughly, it works as follows:
- Volunteers are split into teams, each with a named leader (who is ideally experienced with the tasks on the team's list)
- Event Logistics oversee the setup to ensure it runs smoothly