### PR TITLE
Add support for PR diff comments vs the deployed version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,132 @@ jobs:
         with:
           path: ./site
 
+  changes:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    outputs:
+      build-system: ${{ steps.filter.outputs.build-system }}
+    steps:
+      - name: Check if build system changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build-system:
+              - .github/**/*
+              - requirements.txt
+              - mkdocs.yml
+
+  build-main:
+    needs:
+      - changes
+    if: needs.changes.outputs.build-system == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - run: pip install -r requirements.txt
+
+      - name: Build
+        run: |
+          mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: build-from-main
+          path: ./site
+
+  diff:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - build-main
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download artifact from this branch's build
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+
+      - name: Unpack local build
+        run: |
+          mkdir local
+          pushd local
+          tar --extract --file ../artifact.tar
+          popd
+          mv artifact.tar local.tar
+
+      - name: Download artifact from main branch build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-from-main
+
+      - name: Unpack main build
+        run: |
+          mkdir main
+          pushd main
+          tar --extract --file ../artifact.tar
+          popd
+          mv artifact.tar main.tar
+
+      - name: Diff
+        id: diff
+        run: |
+          set +e
+          diff -ru main local > ./result.diff
+          result=$?
+          set -euo pipefail
+
+          delimiter="gha-delim-$RANDOM-$RANDOM-gha-delim"
+          {
+            echo "diff<<${delimiter}"
+            cat ./result.diff
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+          cat ./result.diff
+
+          if [[ $result -ne 0 ]]
+          then
+            echo has-changes=true >> "$GITHUB_OUTPUT"
+          else
+            echo has-changes=false >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build comment
+        id: build-comment
+        if: always()
+        run: |
+          {
+            if [[ "${{ steps.diff.outputs.has-changes }}" = "true" ]]
+            then
+              echo "🔀 Build diff:"
+              echo '```diff'
+              cat ./result.diff
+              echo '```'
+            else
+              echo "Build has no changes."
+            fi
+          } > ./comment.md
+
+      - name: Post diff to PR
+        uses: thollander/actions-comment-pull-request@v2
+        if: always()
+        with:
+          comment_tag: build-diff
+          filePath: ./comment.md
+
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,6 +146,18 @@ jobs:
           popd
           mv artifact.tar main.tar
 
+      # The compression of the sitemap appears to be non-deterministic, so diffs
+      # aren't useful. There is a non-compressed version also present, so we're
+      # not losing anything by dropping the compressed one.
+      - name: Drop compressed sitemap
+        run: |
+          pushd main
+          [ -f sitemap.xml ] && rm sitemap.xml.gz
+          popd
+          pushd local
+          [ -f sitemap.xml ] && rm sitemap.xml.gz
+          popd
+
       - name: Diff
         id: diff
         run: |


### PR DESCRIPTION
This based on that in the website & docs repos, which have this in place.

See e.g: https://github.com/srobo/docs/pull/593 and https://github.com/srobo/docs/pull/600

I realise that currently we're not pinning our full dependencies, which is probably not optimal here, though I don't think that's a blocker and we can easily add that on later.