### PR TITLE
Expand docs on safety and regs checks

### DIFF
--- a/docs/competition/competition-roles.md
+++ b/docs/competition/competition-roles.md
@@ -12,7 +12,7 @@ Depending on the nature of the event, some of these roles may not be applicable.
 - [Intro Briefer](./event/intro-brief.md)
 - [Refreshments](./volunteers/refreshments.md)
 - [Team Pit Manager](./team-pits/README.md)
-- [Robot Safety Inspector](./matches/README.md#robot-safety-inspections)
+- [Robot Regulations Inspector](./team-support/regulations-inspector.md)
 - Group Photo Photographer
 - [Health and Safety Coordinator](./event/incident-management.md)
 

--- a/docs/competition/matches/README.md
+++ b/docs/competition/matches/README.md
@@ -3,12 +3,3 @@
 At the competition we run a large number of matches, during which the robots
 compete in an Arena. This section provides information about the running of
 those matches.
-
-## Robot safety inspections
-
-Before any robot may compete in a match, it must be inspected to ensure that it
-is safe and complies with the game rules. This is typically organised by the
-volunteer in charge of Health & Safety.
-
-A checklist for such inspections (from SR2016) exists at
-<http://scarzybrook.co.uk/SR/robotinspector.pdf>

--- a/docs/competition/matches/shepherding.md
+++ b/docs/competition/matches/shepherding.md
@@ -60,7 +60,7 @@ More specifically the guard should not allow anyone into the staging area unless
 
   Robots which do not meet the safety or regulations requirements may not compete.
 
-When letting a team (=person with a robot) into the staging area the guard should tell them which corner they will stage for, ideally mentioning the colour and approximate location of the staging desk if possible. We recommend that the guard keeps a record of which teams have already been admitted for a particular match. If the guard sees a team leaving the staging area with robot markers still attached to their robot, she should request that the team return the markers before leaving the staging area.
+When letting a team (i.e. competitor with a robot) into the staging area, the guard should tell them which zone they are in, ideally by saying the colour and number of the zone (e.g. yellow 3). We recommend that the guard keeps a record of which teams have already been admitted for a particular match. If the guard sees a team leaving the staging area with a robot flag or competition mode USB still attached to their robot, they should try to stop them and get the flag and USB back as soon as possible.
 
 
 #### Badgers

--- a/docs/competition/matches/shepherding.md
+++ b/docs/competition/matches/shepherding.md
@@ -53,7 +53,15 @@ If it seems like the timing does not work out (teams waiting for a long time for
 
 The responsibility of the guard is to open and close the staging area at appropriate times and control entry to this area.
 
-More specifically the guard should not allow anyone into the staging area unless they are a blueshirt or staging for the next match. Only one person from each team is allowed in the staging area and they must wear a high-vis vest showing their team name, indicating that they have passed the safety test. When letting a team (=person with a robot) into the staging area the guard should tell them which corner they will stage for, ideally mentioning the colour and approximate location of the staging desk if possible. We recommend that the guard keeps a record of which teams have already been admitted for a particular match. If the guard sees a team leaving the staging area with robot markers still attached to their robot, she should request that the team return the markers before leaving the staging area.
+More specifically the guard should not allow anyone into the staging area unless they are a blueshirt or staging for the next match. Only one person from each team is allowed in the staging area and they must wear a high-vis vest showing their team name, indicating that they have passed the safety and regulations checks.
+
+!!! warning
+  If a robot no longer meets the safety or regulations checks, confiscate their battery or hi-viz respectively and suggest they contact helpdesk immediately.
+
+  Robots which do not meet the safety or regulations requirements may not compete.
+
+When letting a team (=person with a robot) into the staging area the guard should tell them which corner they will stage for, ideally mentioning the colour and approximate location of the staging desk if possible. We recommend that the guard keeps a record of which teams have already been admitted for a particular match. If the guard sees a team leaving the staging area with robot markers still attached to their robot, she should request that the team return the markers before leaving the staging area.
+
 
 #### Badgers
 

--- a/docs/competition/matches/shepherding.md
+++ b/docs/competition/matches/shepherding.md
@@ -53,7 +53,7 @@ If it seems like the timing does not work out (teams waiting for a long time for
 
 The responsibility of the guard is to open and close the staging area at appropriate times and control entry to this area.
 
-More specifically the guard should not allow anyone into the staging area unless they are a blueshirt or staging for the next match. Only one person from each team is allowed in the staging area and they must wear a high-vis vest showing their team name, indicating that they have passed the safety and regulations checks.
+More specifically the guard should not allow anyone into the staging area unless they are a blueshirt or staging for the next match. Only one person from each team is allowed in the staging area and they must wear a high-vis vest showing their team name, indicating that they have passed the safety and regulations checks. If they do not have a high-vis, they may not compete.
 
 !!! warning
   If a robot no longer meets the safety or regulations checks, confiscate their battery or hi-viz respectively and suggest they contact helpdesk immediately.

--- a/docs/competition/team-support/helpdesk.md
+++ b/docs/competition/team-support/helpdesk.md
@@ -40,7 +40,7 @@ Whenever a team comes to Helpdesk with an issue that cannot be solved instantly,
 
 The robots require safety checking before they are allowed to compete in the competition. Teams will not be given their hi-viz vest until their robot has passed the safety check procedure. Helpdesk volunteers should perform a safety check according to the [safety checklist](https://docs.google.com/document/d/1psLhgLw21m1u2BwGJHi6IEMYQTLhcjWmQdhJ_6tLQUE/edit) and record the result.
 
-Regulations checks will be done by other volunteers visiting a team in their pit. Helpdesk volunteers do not need to do regulations checks, but may need to answer questions.
+Regulations checks will be done by [other volunteers](./regulations-inspector.md) visiting a team in their pit. Helpdesk volunteers do not need to do regulations checks, but may need to answer questions.
 
 ### General robot development queries
 

--- a/docs/competition/team-support/helpdesk.md
+++ b/docs/competition/team-support/helpdesk.md
@@ -38,7 +38,7 @@ Whenever a team comes to Helpdesk with an issue that cannot be solved instantly,
 
 ### Robot safety checks
 
-The robots require safety checking before they are allowed to compete in the competition. Teams will not be given their hi-viz vest until their robot has passed the safety check procedure. Helpdesk volunteers should perform a safety check according to the [safety checklist](https://docs.google.com/document/d/1psLhgLw21m1u2BwGJHi6IEMYQTLhcjWmQdhJ_6tLQUE/edit) and record the result.
+The robots require safety checking before they are allowed to compete in the competition. Teams must not be given a battery until their robot has passed the safety check procedure. Helpdesk volunteers should perform a safety check according to the [safety checklist](https://docs.google.com/document/d/1psLhgLw21m1u2BwGJHi6IEMYQTLhcjWmQdhJ_6tLQUE/edit) and record the result.
 
 Regulations checks will be done by [other volunteers](./regulations-inspector.md) visiting a team in their pit. Helpdesk volunteers do not need to do regulations checks, but may need to answer questions.
 

--- a/docs/competition/team-support/regulations-inspector.md
+++ b/docs/competition/team-support/regulations-inspector.md
@@ -1,6 +1,6 @@
 # Regulations Inspector
 
-Before any robot may compete in a match, it must be inspected to ensure that it complies with the game rules. Regulations checks are performed by volunteers visiting a team in their pit. Teams with earlier matches should be checked firstThe Robot Regulations Checklist ([example][robot-regulations-checklist]) should be used to inspect a robot.
+Before any robot may compete in a match, it must be inspected to ensure that it complies with the game rules. Regulations checks are performed by volunteers visiting a team in their pit. Teams with earlier matches should be checked first. The Robot Regulations Checklist ([example][robot-regulations-checklist]) should be used to inspect a robot.
 
 !!! warning
     A team should not be regulations checked until they have passed a safety check. If a team has not yet passed a safety check, suggest they contact helpdesk immediately.

--- a/docs/competition/team-support/regulations-inspector.md
+++ b/docs/competition/team-support/regulations-inspector.md
@@ -1,0 +1,12 @@
+# Regulations Inspector
+
+Before any robot may compete in a match, it must be inspected to ensure that it complies with the game rules. Regulations checks are performed by volunteers visiting a team in their pit. Teams with earlier matches should be checked firstThe Robot Regulations Checklist ([example][robot-regulations-checklist]) should be used to inspect a robot.
+
+!!! warning
+    A team should not be regulations checked until they have passed a safety check. If a team has not yet passed a safety check, suggest they contact helpdesk immediately.
+
+Once a team has passed a regulations inspection, they should be given a hi-viz. This is used by staging to confirm they have passed.
+
+In some cases, a team may change their robot such that it is no longer safe or complies with the regulations. In this case, confiscate their hi-viz until they pass. If a robot is no longer safe, additionally confiscate their battery.
+
+[robot-regulations-checklist]: https://docs.google.com/document/d/1Gn6y1TKOX0oSw38P8azx2XPAylW3LEubdxKxBJVnQQU/edit


### PR DESCRIPTION
This year, regs and safety checks are handed separately:

- Safety checks are done first, and are required before a team gets a battery. These are done at Helpdesk (docs already in place)
- Regs checks are done by volunteers visiting teams, and use a hi-viz to mark teams which have passed.

Staging can use a hi-viz to identify passes, and revoke them easily should the robot fail.