### PR TITLE
Mkdocs tweaks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,13 +65,11 @@ extra:
 
 # Extensions
 markdown_extensions:
-  # Note: the mermaid2 plugin also relies on code blocks for graphs, which isn't
-  # completely compatible with the following extensions, so we keep them
-  # disabled. If we turn out to need code blocks in this project, we can
-  # solve this then. See https://github.com/fralau/mkdocs-mermaid2-plugin#using-mermaid-and-code-highlighting-at-the-same-time.
-  # - markdown.extensions.codehilite
-  # - pymdownx.superfences
-
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid
   - footnotes
   - markdown.extensions.admonition
   - markdown.extensions.def_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.indexes
     - content.action.edit
     - content.action.view
+    - search.suggest
   font:
     text: Open Sans
 copyright: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,8 +9,32 @@ theme:
     logo: fontawesome/solid/book
   favicon: favicon.ico
   palette:
-    primary: 'blue'
-    accent: 'blue'
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+
   custom_dir: theme
   features:
     - navigation.tabs
@@ -70,6 +94,9 @@ markdown_extensions:
   - mdx_include:
       base_path: docs
   - attr_list
+
+extra_css:
+  - assets/runbook.css
 
 
 plugins:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,8 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   icon:
-    logo: fontawesome/solid/book
+    logo: fontawesome/solid/book-open-reader
+    repo: fontawesome/brands/github
   favicon: favicon.ico
   palette:
     # Palette toggle for automatic mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,3 +73,6 @@ plugins:
   - search
   - markdownextradata
   - mermaid2
+  - git-revision-date-localized:
+      enable_creation_date: true
+      fallback_to_build_date: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ theme:
   custom_dir: theme
   features:
     - navigation.tabs
-    - navigation.index
+    - navigation.indexes
     - content.action.edit
     - content.action.view
   font:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ theme:
     - navigation.index
     - content.action.edit
     - content.action.view
+  font:
+    text: Open Sans
 copyright: |
   Copyright &copy; Student Robotics contributors
   <br>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ mkdocs-material==9.6.4
 mdx-include==1.4.2
 mkdocs-markdownextradata-plugin==0.2.6
 mkdocs-mermaid2-plugin==1.2.1
+mkdocs-git-revision-date-localized-plugin==1.4.7
 
 # 4.13.0 deprecates some APIs used by mkdocs-mermaid2-plugin.
 # Pin to an older version to silence warnings.

--- a/theme/assets/runbook.css
+++ b/theme/assets/runbook.css
@@ -1,0 +1,7 @@
+div.mermaid svg {
+  /*
+    Force mermaid diagrams to have a light background
+  */
+  background-color: white;
+  color: black;
+}


### PR DESCRIPTION
`mkdocs-material` has a number of nice features we weren't using. Given they're there, we might as well be taking advantage of them. Specifically:

- Showing created and modified dates at the bottom of content
- Dark mode :partying_face: (uses user preferences, plus with explicit toggle)
- Search suggestions
- Restore `superfences` for syntax highlighting, as the mermaid plugin has support for this now
- Set the font to Open Sans to match our brand
- Tweak the navbar icons, particularly repository link

Also fixes showing section indexes when you click the dropdown - this was broken since a previous update. Note that the pages were still accessible, they just required an extra click to access.